### PR TITLE
Add support for live preview mode

### DIFF
--- a/.changes/live-preview.md
+++ b/.changes/live-preview.md
@@ -1,0 +1,5 @@
+---
+"obsidian-css-inlay-colors": minor:feat
+---
+
+Show inlay colors in live preview mode

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
     paths:
       - "biome.json"
-      - "main.ts"
+      - "*.ts"
       - "package.json"
       - "tsconfig.json"
       - "yarn.lock"

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ To use, just put any valid CSS color syntax in a code block like so: \`#8A5CF5\`
 This plugin is still in alpha. Before v1.0.0 is released I want to finish the following features:
 
 - [x] Show colors in reading mode
-- [ ] Show colors in live preview mode
+- [x] Show colors in live preview mode
 - [ ] Edit colors with a color picker in live preview mode
 
 ## Development

--- a/src/live.ts
+++ b/src/live.ts
@@ -1,0 +1,98 @@
+import { syntaxTree } from '@codemirror/language'
+import type { Range } from '@codemirror/state'
+import {
+  Decoration,
+  type DecorationSet,
+  type EditorView,
+  ViewPlugin,
+  type ViewUpdate,
+  WidgetType,
+} from '@codemirror/view'
+import { type Color, parse } from 'culori'
+
+class CSSColorInlayWidget extends WidgetType {
+  constructor(
+    readonly color: Color,
+    readonly original: string,
+  ) {
+    super()
+  }
+
+  eq(other: CSSColorInlayWidget) {
+    return other.color === this.color
+  }
+
+  toDOM() {
+    // const picker = document.createElement('input')
+    // picker.type = 'color'
+    // picker.value = this.color
+
+    const inlay = document.createElement('span')
+    inlay.className = 'css-color-inlay'
+    inlay.style.background = this.original
+
+    const wrapper = document.createElement('span')
+    wrapper.className = 'cm-inline-code css-color-wrapper'
+    wrapper.append(inlay)
+
+    return wrapper
+  }
+
+  ignoreEvent() {
+    return false
+  }
+}
+
+export function inlayExtension() {
+  return ViewPlugin.fromClass(
+    class {
+      decorations: DecorationSet = Decoration.none
+
+      constructor(public view: EditorView) {
+        this.decorations = createColorWidgets(view)
+      }
+
+      update(update: ViewUpdate) {
+        if (
+          update.docChanged ||
+          update.viewportChanged ||
+          syntaxTree(update.startState) !== syntaxTree(update.state)
+        ) {
+          this.decorations = createColorWidgets(update.view)
+        }
+      }
+    },
+    {
+      decorations: (v) => v.decorations,
+    },
+  )
+}
+
+function createColorWidgets(view: EditorView) {
+  const widgets: Range<Decoration>[] = []
+
+  for (const { from, to } of view.visibleRanges) {
+    syntaxTree(view.state).iterate({
+      from,
+      to,
+      enter: (node) => {
+        if (node.name === 'inline-code') {
+          const original = view.state.sliceDoc(node.from, node.to)
+          const color = parse(original)
+
+          // Not a valid color
+          if (color === undefined) return
+
+          const deco = Decoration.widget({
+            side: 1,
+            widget: new CSSColorInlayWidget(color, original),
+          })
+
+          widgets.push(deco.range(node.from))
+        }
+      },
+    })
+  }
+
+  return Decoration.set(widgets)
+}

--- a/src/live.ts
+++ b/src/live.ts
@@ -8,13 +8,10 @@ import {
   type ViewUpdate,
   WidgetType,
 } from '@codemirror/view'
-import { type Color, parse } from 'culori'
+import { parse } from 'culori'
 
 class CSSColorInlayWidget extends WidgetType {
-  constructor(
-    readonly color: Color,
-    readonly original: string,
-  ) {
+  constructor(readonly color: string) {
     super()
   }
 
@@ -23,23 +20,15 @@ class CSSColorInlayWidget extends WidgetType {
   }
 
   toDOM() {
-    // const picker = document.createElement('input')
-    // picker.type = 'color'
-    // picker.value = this.color
-
     const inlay = document.createElement('span')
     inlay.className = 'css-color-inlay'
-    inlay.style.background = this.original
+    inlay.style.background = this.color
 
     const wrapper = document.createElement('span')
     wrapper.className = 'cm-inline-code css-color-wrapper'
     wrapper.append(inlay)
 
     return wrapper
-  }
-
-  ignoreEvent() {
-    return false
   }
 }
 
@@ -77,15 +66,14 @@ function createColorWidgets(view: EditorView) {
       to,
       enter: (node) => {
         if (node.name === 'inline-code') {
-          const original = view.state.sliceDoc(node.from, node.to)
-          const color = parse(original)
+          const color = view.state.sliceDoc(node.from, node.to)
 
           // Not a valid color
-          if (color === undefined) return
+          if (parse(color) === undefined) return
 
           const deco = Decoration.widget({
             side: 1,
-            widget: new CSSColorInlayWidget(color, original),
+            widget: new CSSColorInlayWidget(color),
           })
 
           widgets.push(deco.range(node.from))

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,71 +1,64 @@
-import { parse } from 'culori'
-import { Plugin } from 'obsidian'
+import { type App, Plugin, PluginSettingTab, Setting } from 'obsidian'
+import { inlayPostProcessor } from 'src/preview'
+import { inlayExtension } from './live'
 
-// interface CssColorsPluginSettings {
-//   showInLiveEditor: boolean
-// }
+interface CssColorsPluginSettings {
+  showInLiveEditor: boolean
+}
 
-// const DEFAULT_SETTINGS: CssColorsPluginSettings = {
-//   showInLiveEditor: true,
-// }
+const DEFAULT_SETTINGS: CssColorsPluginSettings = {
+  showInLiveEditor: true,
+}
 
 export default class CssColorsPlugin extends Plugin {
-  // settings: CssColorsPluginSettings = DEFAULT_SETTINGS
+  settings: CssColorsPluginSettings = DEFAULT_SETTINGS
 
   async onload() {
-    // await this.loadSettings()
+    await this.loadSettings()
 
-    this.registerMarkdownPostProcessor((el) => {
-      for (const code of el.findAll('code')) {
-        const text = code.innerText.trim()
-        const color = parse(text)
-        if (color !== undefined) {
-          code.createSpan({
-            prepend: true,
-            cls: 'css-color-inlay',
-            attr: { style: `background: ${text};` },
-          })
-        }
-      }
-    })
+    this.registerMarkdownPostProcessor(inlayPostProcessor)
 
-    // this.addSettingTab(new CssColorsSettingsTab(this.app, this))
+    if (this.settings.showInLiveEditor) {
+      this.registerEditorExtension(inlayExtension())
+    }
+
+    this.addSettingTab(new CssColorsSettingsTab(this.app, this))
   }
 
   onunload() {}
 
-  // async loadSettings() {
-  //   this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData())
-  // }
+  async loadSettings() {
+    this.settings = Object.assign({}, DEFAULT_SETTINGS, await this.loadData())
+  }
 
-  // async saveSettings() {
-  //   await this.saveData(this.settings)
-  // }
+  async saveSettings() {
+    await this.saveData(this.settings)
+  }
 }
 
-// class CssColorsSettingsTab extends PluginSettingTab {
-//   plugin: CssColorsPlugin
+class CssColorsSettingsTab extends PluginSettingTab {
+  plugin: CssColorsPlugin
 
-//   constructor(app: App, plugin: CssColorsPlugin) {
-//     super(app, plugin)
-//     this.plugin = plugin
-//   }
+  constructor(app: App, plugin: CssColorsPlugin) {
+    super(app, plugin)
+    this.plugin = plugin
+  }
 
-//   display(): void {
-//     const { containerEl } = this
+  display(): void {
+    const { containerEl } = this
 
-//     containerEl.empty()
+    containerEl.empty()
 
-//     new Setting(containerEl)
-//       .setName('Show in live editor')
-//       .setDesc('Enable colors in the live editor')
-//       .addToggle((toggle) =>
-//         toggle
-//           .setValue(this.plugin.settings.showInLiveEditor)
-//           .onChange(async (value) => {
-//             this.plugin.settings.showInLiveEditor = value
-//             await this.plugin.saveSettings()
-//           }),
-//       )
-//   }
-// }
+    new Setting(containerEl)
+      .setName('Show in live editor')
+      .setDesc('Enable colors in the live editor')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.showInLiveEditor)
+          .onChange(async (value) => {
+            this.plugin.settings.showInLiveEditor = value
+            await this.plugin.saveSettings()
+          }),
+      )
+  }
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -51,7 +51,7 @@ class CssColorsSettingsTab extends PluginSettingTab {
 
     new Setting(containerEl)
       .setName('Show in live editor')
-      .setDesc('Enable colors in the live editor')
+      .setDesc('Enable colors in the live editor (requires reload)')
       .addToggle((toggle) =>
         toggle
           .setValue(this.plugin.settings.showInLiveEditor)

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,0 +1,15 @@
+import { parse } from 'culori'
+
+export function inlayPostProcessor(el: HTMLElement) {
+  for (const code of el.findAll('code')) {
+    const text = code.innerText.trim()
+    const color = parse(text)
+    if (color !== undefined) {
+      code.createSpan({
+        prepend: true,
+        cls: 'css-color-inlay',
+        attr: { style: `background: ${text};` },
+      })
+    }
+  }
+}

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -2,14 +2,15 @@ import { parse } from 'culori'
 
 export function inlayPostProcessor(el: HTMLElement) {
   for (const code of el.findAll('code')) {
-    const text = code.innerText.trim()
-    const color = parse(text)
-    if (color !== undefined) {
-      code.createSpan({
-        prepend: true,
-        cls: 'css-color-inlay',
-        attr: { style: `background: ${text};` },
-      })
-    }
+    const color = code.innerText.trim()
+
+    // Not a valid color
+    if (parse(color) === undefined) return
+
+    code.createSpan({
+      prepend: true,
+      cls: 'css-color-inlay',
+      attr: { style: `background: ${color};` },
+    })
   }
 }

--- a/styles.css
+++ b/styles.css
@@ -8,3 +8,16 @@
   margin-right: .3em;
   margin-top: -.1em;
 }
+
+/* Make inlay colors in the live editor appear part of the code block */
+.css-color-wrapper.cm-inline-code:not(.cm-formatting) {
+  padding-inline-end: 0;
+  border-start-end-radius: 0;
+  border-end-end-radius: 0;
+
+  & + .cm-inline-code:not(.cm-formatting) {
+    padding-inline-start: 0;
+    border-start-start-radius: 0;
+    border-end-start-radius: 0;
+  }
+}


### PR DESCRIPTION
Adds a codemirror extension that inserts inlay color widgets in live preview mode. Attempts to style them to match how they appear in preview mode.