### PR TITLE
Fix inlay not working in lists in edit/live preview

### DIFF
--- a/.changes/fix-lists.md
+++ b/.changes/fix-lists.md
@@ -1,0 +1,5 @@
+---
+"obsidian-css-inlay-colors": patch:fix
+---
+
+Fix inlay not showing for colors in an ordered/unordered list in live preview mode

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,10 +10,6 @@ concurrency: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   version-or-release:
     runs-on: ubuntu-latest
-    outputs:
-      releaseId: ${{ steps.covector.outputs.releaseId }}
-      commandRan: ${{ steps.covector.outputs.commandRan }}
-      shouldPublish: ${{ steps.covector.outputs.published-obsidian-css-inlay-colors }}
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "obsidian-css-inlay-colors",
   "version": "0.2.0",
   "packageManager": "yarn@4.3.1",
-  "description": "Show inline color hints for CSS colors in Obsidian",
+  "description": "Show inline color hints for CSS colors",
   "main": "main.js",
   "scripts": {
     "dev": "node esbuild.config.mjs",

--- a/src/live.ts
+++ b/src/live.ts
@@ -65,7 +65,7 @@ function createColorWidgets(view: EditorView) {
       from,
       to,
       enter: (node) => {
-        if (node.name === 'inline-code') {
+        if (node.name.includes('inline-code')) {
           const color = view.state.sliceDoc(node.from, node.to)
 
           // Not a valid color


### PR DESCRIPTION
Fixes #5

Looks like inline code blocks in lists use a different node name, so I've made my code less strict when checking for code blocks.