### PR TITLE
Add option to hide CSS color names

### DIFF
--- a/.changes/hide-names.md
+++ b/.changes/hide-names.md
@@ -1,0 +1,5 @@
+---
+"obsidian-css-inlay-colors": minor:feat
+---
+
+Adds a setting to hide color names so only the inlay swatch is visible

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,16 +1,11 @@
-import { type App, Plugin, PluginSettingTab, Setting } from 'obsidian'
+import { Plugin } from 'obsidian'
 import { inlayPostProcessor } from 'src/preview'
 import { inlayExtension } from './live'
-
-interface CssColorsPluginSettings {
-  showInLiveEditor: boolean
-  colorPickerEnabled: boolean
-}
-
-const DEFAULT_SETTINGS: CssColorsPluginSettings = {
-  showInLiveEditor: true,
-  colorPickerEnabled: false,
-}
+import {
+  type CssColorsPluginSettings,
+  CssColorsSettingsTab,
+  DEFAULT_SETTINGS,
+} from './settings'
 
 export default class CssColorsPlugin extends Plugin {
   settings: CssColorsPluginSettings = DEFAULT_SETTINGS
@@ -18,7 +13,7 @@ export default class CssColorsPlugin extends Plugin {
   async onload() {
     await this.loadSettings()
 
-    this.registerMarkdownPostProcessor(inlayPostProcessor)
+    this.registerMarkdownPostProcessor(inlayPostProcessor(this.settings))
 
     if (this.settings.showInLiveEditor) {
       this.registerEditorExtension(
@@ -37,48 +32,5 @@ export default class CssColorsPlugin extends Plugin {
 
   async saveSettings() {
     await this.saveData(this.settings)
-  }
-}
-
-class CssColorsSettingsTab extends PluginSettingTab {
-  plugin: CssColorsPlugin
-
-  constructor(app: App, plugin: CssColorsPlugin) {
-    super(app, plugin)
-    this.plugin = plugin
-  }
-
-  display(): void {
-    const { containerEl } = this
-
-    containerEl.empty()
-
-    new Setting(containerEl)
-      .setName('Show in live preview mode')
-      .setDesc('Enable color inlays in the live preview (requires reload).')
-      .addToggle((toggle) =>
-        toggle
-          .setValue(this.plugin.settings.showInLiveEditor)
-          .onChange(async (value) => {
-            this.plugin.settings.showInLiveEditor = value
-            await this.plugin.saveSettings()
-          }),
-      )
-
-    new Setting(containerEl)
-      .setName('Enable the color picker')
-      .setDesc('Allows you to edit a color by clicking on the inlay.')
-      .addToggle((toggle) =>
-        toggle
-          .setValue(this.plugin.settings.colorPickerEnabled)
-          .onChange(async (value) => {
-            this.plugin.settings.colorPickerEnabled = value
-            await this.plugin.saveSettings()
-          }),
-      )
-      .descEl.createDiv({
-        text: 'Opacity and colors outside of the sRGB color space are not supported.',
-        cls: 'mod-warning',
-      })
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -16,9 +16,7 @@ export default class CssColorsPlugin extends Plugin {
     this.registerMarkdownPostProcessor(inlayPostProcessor(this.settings))
 
     if (this.settings.showInLiveEditor) {
-      this.registerEditorExtension(
-        inlayExtension(this.settings.colorPickerEnabled),
-      )
+      this.registerEditorExtension(inlayExtension(this.settings))
     }
 
     this.addSettingTab(new CssColorsSettingsTab(this.app, this))

--- a/src/preview.ts
+++ b/src/preview.ts
@@ -1,20 +1,27 @@
 import { parse } from 'culori'
+import type { CssColorsPluginSettings } from './settings'
 
-export const inlayPostProcessor = (el: HTMLElement) => {
-  for (const code of el.findAll('code')) {
-    const color = code.innerText.trim()
+export const inlayPostProcessor =
+  (settings: CssColorsPluginSettings) => (el: HTMLElement) => {
+    for (const code of el.findAll('code')) {
+      const color = code.innerText.trim()
 
-    // Not a valid color
-    try {
-      if (parse(color) === undefined) return
-    } catch {
-      return
+      // Not a valid color
+      try {
+        if (parse(color) === undefined) return
+      } catch {
+        return
+      }
+
+      // Clear codeblock before adding inlay
+      if (settings.hideNames) {
+        code.innerHTML = ''
+      }
+
+      code.createSpan({
+        prepend: true,
+        cls: `css-color-inlay ${settings.hideNames ? 'css-color-name-hidden' : ''}`,
+        attr: { style: `--css-color-inlay-color: ${color};` },
+      })
     }
-
-    code.createSpan({
-      prepend: true,
-      cls: 'css-color-inlay',
-      attr: { style: `--css-color-inlay-color: ${color};` },
-    })
   }
-}

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,71 @@
+import { type App, PluginSettingTab, Setting } from 'obsidian'
+import type CssColorsPlugin from './main'
+
+export interface CssColorsPluginSettings {
+  showInLiveEditor: boolean
+  colorPickerEnabled: boolean
+  hideNames: boolean
+}
+
+export const DEFAULT_SETTINGS: CssColorsPluginSettings = {
+  showInLiveEditor: true,
+  colorPickerEnabled: false,
+  hideNames: false,
+}
+
+export class CssColorsSettingsTab extends PluginSettingTab {
+  plugin: CssColorsPlugin
+
+  constructor(app: App, plugin: CssColorsPlugin) {
+    super(app, plugin)
+    this.plugin = plugin
+  }
+
+  display(): void {
+    const { containerEl } = this
+
+    containerEl.empty()
+
+    new Setting(containerEl)
+      .setName('Show in live preview mode')
+      .setDesc('Enable color inlays in the live preview (requires reload).')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.showInLiveEditor)
+          .onChange(async (value) => {
+            this.plugin.settings.showInLiveEditor = value
+            await this.plugin.saveSettings()
+          }),
+      )
+
+    new Setting(containerEl)
+      .setName('Enable the color picker')
+      .setDesc('Allows you to edit a color by clicking on the inlay.')
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.colorPickerEnabled)
+          .onChange(async (value) => {
+            this.plugin.settings.colorPickerEnabled = value
+            await this.plugin.saveSettings()
+          }),
+      )
+      .descEl.createDiv({
+        text: 'Opacity and colors outside of the sRGB color space are not supported.',
+        cls: 'mod-warning',
+      })
+
+    new Setting(containerEl)
+      .setName('Hide color names')
+      .setDesc(
+        'Hides the inline code block in live preview and reading mode so only the color inlay is visible.',
+      )
+      .addToggle((toggle) =>
+        toggle
+          .setValue(this.plugin.settings.hideNames)
+          .onChange(async (value) => {
+            this.plugin.settings.hideNames = value
+            await this.plugin.saveSettings()
+          }),
+      )
+  }
+}

--- a/styles.css
+++ b/styles.css
@@ -21,7 +21,7 @@
 }
 
 /* Make inlay colors in the live editor appear part of the code block */
-.css-color-wrapper.cm-inline-code:not(.cm-formatting) {
+.css-color-wrapper:not(:has(.css-color-name-hidden)).cm-inline-code:not(.cm-formatting) {
   padding-inline-end: 0;
   border-start-end-radius: 0;
   border-end-end-radius: 0;

--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,10 @@
   margin-top: -.1em;
   background: var(--css-color-inlay-color);
 
+  &.css-color-name-hidden {
+    margin-right: 0;
+  }
+
   input {
     height: 0;
     width: 0;


### PR DESCRIPTION
Adds a setting to hide the inline code block color name and only show the inlay swatch in live preview and reading mode.

Closes #12 